### PR TITLE
added ability to pass in a scrollable element.

### DIFF
--- a/Steady.js
+++ b/Steady.js
@@ -3,6 +3,7 @@ function Steady(opts) {
   if ( !opts.handler ) throw new Error('missing handler parameter');
 
 
+  this.scrollElement = opts.scrollElement || window;
   this.conditions = opts.conditions || {};
   this.handler   = opts.handler;
   this.values    = {};
@@ -132,7 +133,7 @@ Steady.prototype._onScroll = function() {
   var self = this;
   
 
-  window.onscroll = this.throttle(function(e) {
+  this.scrollElement.onscroll = this.throttle(function(e) {
 
     if ( !self._wantedTrackers.length || self.processing ) return;
     


### PR DESCRIPTION
given:

```
<div id="results" style="overflow: scroll;">
  ...
</div>
```

```
var steady = new Steady({
  throttle: 100,
  handler: steadyHandler,
  scrollElement: document.getElementById('results')
});
```
