### PR TITLE
Added support for conditionsMode. Defaults to 'all', but can be set to '...

### DIFF
--- a/Steady.js
+++ b/Steady.js
@@ -1,8 +1,12 @@
 function Steady(opts) {
   if ( !opts ) throw new Error('missing options');
   if ( !opts.handler ) throw new Error('missing handler parameter');
+  if ( opts.conditionsMode && 
+       opts.conditionsMode !== 'all' && 
+       opts.conditionsMode !== 'any' ) throw new Error('The conditionsMode parameter must be "all" or "any"');
 
 
+  this.conditionsMode = opts.conditionsMode || 'all';
   this.scrollElement = opts.scrollElement || window;
   this.conditions = opts.conditions || {};
   this.handler   = opts.handler;
@@ -144,7 +148,10 @@ Steady.prototype._check = function() {
     }
   }
 
-  if ( results.length && results.indexOf(false) == -1 ) {
+  if ( results.length && 
+    (( this.conditionsMode === 'all' && results.indexOf(false) == -1 ) ||
+     ( this.conditionsMode === 'any'  && results.indexOf(true) >= 0 )) 
+  ) {
     this.processing = true;
 
     var cb = this._done.bind(this);


### PR DESCRIPTION
...any'. In 'any' mode, if any of the conditions match, it will enter the handler. This is useful to taking actions at the top of a scrollable element as well as at the bottom.

In the application I am working on, I am implementing the infinite scroll as a sliding window. When you are near the top of the scroll, it will trigger fetching the previous batch of data and adding it to the top. When you are near the bottom of the scroll, it will trigger fetching the next batch of data and adding it to the bottom.

It will only keep a certain number of rows of data (3 pages worth) in browser memory at any given time.
