### PR TITLE
Basic gulp support for linting and qunit

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var gulp  = require('gulp');
+
+// load plugins
+var $ = require('gulp-load-plugins')();
+
+gulp.task('scripts', function () {
+  return gulp.src('Steady.js')
+    .pipe($.jshint())
+    .pipe($.jshint.reporter(require('jshint-stylish')))
+    .pipe($.size());
+});
+
+gulp.task('connect', function () {
+  var connect = require('connect');
+  var app = connect()
+    .use(require('connect-livereload')({ port: 35729 }))
+    .use(connect.static(__dirname))
+    .use(connect.static('tests'));
+
+  require('http').createServer(app)
+    .listen(9000)
+    .on('listening', function () {
+      console.log('Started connect web server on http://localhost:9000');
+    });
+});
+
+gulp.task('serve', ['connect'], function () {
+  require('opn')('http://localhost:9000/tests/test.html');
+});
+
+gulp.task('watch', ['connect', 'serve'], function () {
+  var server = $.livereload();
+
+  // watch for changes
+
+  gulp.watch([
+    'Steady.js',
+    'tests/*.html',
+    'tests/*.js'
+  ]).on('change', function (file) {
+    server.changed(file.path);
+  });
+
+  gulp.watch('Steady.js', ['scripts']);
+});
+
+gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -4,12 +4,20 @@
   "description": "A module to do some logic on the `onscroll` event without performance regressions in a @media-query like conditions.",
   "main": "Steady.js",
   "homepage": "https://github.com/lafikl/steady.js",
-  "scripts": {
-    
-  },
+  "scripts": {},
   "author": "Khalid Lafi",
   "license": "MIT",
   "devDependencies": {
-    "qunitjs": "^1.14.0"
+    "qunitjs": "^1.14.0",
+    "connect": "^2.14.4",
+    "connect-livereload": "^0.4.0",
+    "gulp": "^3.6.0",
+    "gulp-jshint": "^1.5.3",
+    "gulp-livereload": "^1.2.0",
+    "gulp-load-plugins": "^0.5.0",
+    "gulp-size": "^0.3.0",
+    "gulp-uglify": "^0.2.1",
+    "jshint-stylish": "^0.2.0",
+    "opn": "^0.1.1"
   }
 }

--- a/tests/test.html
+++ b/tests/test.html
@@ -6,7 +6,8 @@
   <style type="text/css">
     body {
       height: 400%;
-      width: 100%;
+      left: 0;
+      right: 0;
       position: absolute;
     }
     #scrollable {

--- a/tests/test.js
+++ b/tests/test.js
@@ -68,14 +68,13 @@ QUnit.asyncTest('test resume method', function(assert) {
         
         setTimeout(function() {
           assert.equal(runs, 2, 'resume method runs should equal 2' );
+          s.stop();
           QUnit.start();
         }, 200);
       }, 200);
 
     }, 20);
   });
-  
-  
 });
 
 QUnit.asyncTest('test addCondition', function(assert) {


### PR DESCRIPTION
Fixes #11 

This pull request adds basic support (via gulp) for jshint and automated qunit tests through a local browser.

The default task will watch for changes in either the main script or in the test modules and reload/run the tests as well as running jshint on Steady.js

I had intended to add support for headless testing via phantomjs but wasn't able to quickly get that working quickly.

Reloading the tests exposed a small issue where tests would periodically report as failed then succeed after a refresh.  The small change to tests.js seemed to fix that.
