### PR TITLE
Updates links to new repo.

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
         <a href="#getStarted" class="st-getStarted">Get Started</a>
         <a href="#install" class="st-github-star">Install</a>
-        <a href="https://github.com/lafikl/Steady.js" class="st-github-star">Star on Github</a>
+        <a href="https://github.com/WPOTools/Steady.js" class="st-github-star">Star on Github</a>
     </div>
 
     <div class="st-part" id="getStarted">
@@ -124,7 +124,7 @@
       <code class="st-bash"><b>$</b> bower install Steady.js</code>
 
       <h4>Download</h4>
-      <p>You can download the latest release from <a href="https://github.com/lafikl/steady.js/releases/latest">the github repo</a></p>
+      <p>You can download the latest release from <a href="https://github.com/WPOTools/steady.js/releases/latest">the github repo</a></p>
     </div>
 
     <div class="st-part" id="install">
@@ -144,7 +144,7 @@
       <small>By Khalid Lafi / <a href="#">@LafiKL</a></small>
       <ul class="st-footer-stuff">
         <li class="st-tweet"><a href="https://twitter.com/intent/tweet?text=Steady.js%20%E2%80%93%20A%20module%20to%20work%20on%20the%20%60onscroll%60%20without%20performance%20regressions%20in%20a%20%40media-query%20like%20style.%20http%3A%2F%2Flafikl.github.io%2Fsteady.js%2F" target="_blank">Tweet</a></li>
-        <li><a href="https://github.com/lafikl/steady.js">Source Code</a></li>
+        <li><a href="https://github.com/WPOTools/steady.js">Source Code</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
If you wind up on the gh-pages for this project, it's surprisingly difficult to get to the actual repo. There are no links to it. They all point to the old repo, which then points back to the gh-pages for this repo. lol

See Also:
- http://wpotools.github.io/steady.js/
- https://github.com/lafikl/steady.js
